### PR TITLE
Get rid of _resumeDetection method on the braille handler

### DIFF
--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -269,15 +269,18 @@ class Detector(object):
 
 	def handleWindowMessage(self, msg=None, wParam=None):
 		if msg == WM_DEVICECHANGE and wParam == DBT_DEVNODES_CHANGED:
-			self.rescan()
+			self.rescan(limitToDevices=self._limitToDevices)
 
 	def pollBluetoothDevices(self):
 		"""Poll bluetooth devices that might be in range.
 		This does not cancel the current scan."""
+		if not self._detectBluetooth:
+			# Do not poll bluetooth devices at all when bluetooth is disabled.
+			return
 		with self._btDevsLock:
 			if not self._btDevs:
 				return
-		self._startBgScan(bluetooth=True)
+		self._startBgScan(bluetooth=True, limitToDevices=self._limitToDevices)
 
 	def terminate(self):
 		appModuleHandler.post_appSwitch.unregister(self.pollBluetoothDevices)

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -172,8 +172,9 @@ class Detector(object):
 		self._stopEvent = threading.Event()
 		self._queuedScanLock = threading.Lock()
 		self._scanQueued = False
-		self._detectUsb = False
-		self._detectBluetooth = False
+		self._detectUsb = usb
+		self._detectBluetooth = bluetooth
+		self._limitToDevices = limitToDevices
 		self._runningApcLock = threading.Lock()
 		# Perform initial scan.
 		self._startBgScan(usb=usb, bluetooth=bluetooth, limitToDevices=limitToDevices)

--- a/source/bdDetect.py
+++ b/source/bdDetect.py
@@ -269,7 +269,7 @@ class Detector(object):
 
 	def handleWindowMessage(self, msg=None, wParam=None):
 		if msg == WM_DEVICECHANGE and wParam == DBT_DEVNODES_CHANGED:
-			self.rescan(limitToDevices=self._limitToDevices)
+			self.rescan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
 
 	def pollBluetoothDevices(self):
 		"""Poll bluetooth devices that might be in range.
@@ -280,7 +280,7 @@ class Detector(object):
 		with self._btDevsLock:
 			if not self._btDevs:
 				return
-		self._startBgScan(bluetooth=True, limitToDevices=self._limitToDevices)
+		self._startBgScan(bluetooth=self._detectBluetooth, limitToDevices=self._limitToDevices)
 
 	def terminate(self):
 		appModuleHandler.post_appSwitch.unregister(self.pollBluetoothDevices)

--- a/source/braille.py
+++ b/source/braille.py
@@ -1669,8 +1669,10 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				self.display = newDisplay
 			self.displaySize = newDisplay.numCells
 			self.enabled = bool(self.displaySize)
-			if isFallback:
-				self._resumeDetection()
+			if isFallback and self._detectionEnabled:
+				# As this is the fallback display, which is noBraille,
+				# we can keep the current display when enabling detection.
+				self.__enableDetection(keepCurrentDisplay=True)
 			elif not detected:
 				config.conf["braille"]["display"] = name
 			else: # detected:
@@ -1684,7 +1686,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 				# We should handle this more gracefully, since this is no reason
 				# to stop a display from loading successfully.
 				log.debugWarning("Error in initial display after display load", exc_info=True)
-			if detected and detected.type in (bdDetect.KEY_SERIAL, bdDetect.KEY_HID,) and 'bluetoothName' in detected.deviceInfo:
+			if detected and and 'bluetoothName' in detected.deviceInfo:
 				self._enableDetection(bluetooth=False, keepCurrentDisplay=True, limitToDevices=[name])
 			return True
 		except:
@@ -1996,6 +1998,7 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 	def _enableDetection(self, usb=True, bluetooth=True, keepCurrentDisplay=False, limitToDevices=None):
 		"""Enables automatic detection of braille displays.
 		When auto detection is already active, this will force a rescan for devices.
+		This should also be executed when auto detection should be resumed due to loss of display connectivity.
 		"""
 		if self._detectionEnabled and self._detector:
 			self._detector.rescan(usb=usb, bluetooth=bluetooth, limitToDevices=limitToDevices)
@@ -2015,14 +2018,6 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self._detector.terminate()
 			self._detector = None
 		self._detectionEnabled = False
-
-	def _resumeDetection(self):
-		"""Resumes automatic detection of braille displays.
-		This is executed when auto detection should be resumed due to loss of display connectivity.
-		"""
-		if not self._detectionEnabled or self._detector:
-			return
-		self._detector = bdDetect.Detector()
 
 class _BgThread:
 	"""A singleton background thread used for background writes and raw braille display I/O.

--- a/source/braille.py
+++ b/source/braille.py
@@ -1670,8 +1670,9 @@ class BrailleHandler(baseObject.AutoPropertyObject):
 			self.displaySize = newDisplay.numCells
 			self.enabled = bool(self.displaySize)
 			if isFallback and self._detectionEnabled:
-				# As this is the fallback display, which is noBraille,
+				# As this is the fallback display, which is usually noBraille,
 				# we can keep the current display when enabling detection.
+				# Note that in this case, L{_detectionEnabled} is set by L{handleDisplayUnavailable}
 				self.__enableDetection(keepCurrentDisplay=True)
 			elif not detected:
 				config.conf["braille"]["display"] = name


### PR DESCRIPTION
Though I've not been able to test this yet, I hope that this will make things easier to understand and also fix the bug where the detector keeps the limitToDevices list when the connection drops. Flow is now as follows:

1. One connects a bluetooth device
2. bdDetect keeps scanning in the background for usb alternatives of the current bluetooth device
3. Either
    a. A usb device is connected, NVDA switches to it and detection is disabled until an error occurs
    b. The bluetooth connection is lost. A rescan is triggered with limitToDevices set to None.